### PR TITLE
docs: add Cursor Cloud dev-environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,22 @@ Tests are in AssemblyFolder/Tests in its own assembly
 To allow tests to see private methods/fields, add [assembly: InternalsVisibleTo("AssemblyName.Tests")]. Then create new properties `internal InternalXYZ => XYZ` or methods like XYZForTesting
 A similar pattern can be done to get access to private fields in Editor inspector extensions
 Use NSubstitute for mocking dependencies
+
+## Cursor Cloud specific instructions
+
+This section is durable guidance for cloud agents running in the headless VM (the update script already ran).
+
+### The Unity game cannot be run/built/tested in the cloud VM
+
+- This is a Unity `6000.5.1f1` game. The **Unity Editor is NOT installed** in the cloud VM and is not part of the update script (it is a multi-GB system dependency that also requires a Unity license). Cloud agents therefore cannot open the project, enter Play mode, build a player, or run the Unity Test Framework tests (EditMode/PlayMode) headlessly.
+- Tests run only in **CI**: `.github/workflows/tests.yml` uses `game-ci/unity-test-runner` inside `unityci/editor:ubuntu-6000.5.1f1-base-3` and needs the `UNITY_LICENSE`, `UNITY_EMAIL`, `UNITY_PASSWORD` repo secrets. Reproducing this locally requires Docker + those same secrets.
+- Do not try to compile the C# assemblies standalone (`dotnet`/`mono`): they depend on `UnityEngine` and are only compiled by the Unity Editor. Verify Unity C# changes by reasoning + CI; the human runs the Editor locally (see the Testing section above).
+
+### What IS runnable in the cloud VM: the Python asset tooling under `python/`
+
+`pillow` and `requests` are installed system-wide by the update script. Both tools use paths relative to the current working directory, so run them from the directories noted below.
+
+- **`python/sprite_generator`** (procedural pixel-ship sprite PNGs): run from `python/` with
+  `python3 -c "from sprite_generator.pipeline import run_pipeline; run_pipeline()"`.
+  It reads `sprite_generator/raw_sprites.txt` (gitignored — you must create it: a line ending in `.txt` names a sprite, followed by rows of digits `0`–`7`), writes parsed per-sprite files to `sprite_generator/inputs/`, and outputs PNGs to `Assets/Sprites/Generated/New/`. Path quirk: the output dir is relative to CWD, so running from `python/` writes to `python/Assets/...`, not the repo-root `Assets/`; `cd` to repo root (or adjust) if you want the real assets folder. Faction/armor palette is chosen by filename (`enemy` / `_armor` substrings).
+- **`python/icon_downloader`** (Design System Material Symbols icons): run from `python/icon_downloader/` with `python3 main.py`. Needs network access to `https://api.iconify.design`; writes SVGs into `Assets/DesignSystem/Resources/Textures/Icons/` and appends rules to `Icons.uss` (edits tracked files — review before committing).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,11 +72,27 @@ Use NSubstitute for mocking dependencies
 
 This section is durable guidance for cloud agents running in the headless VM (the update script already ran).
 
-### The Unity game cannot be run/built/tested in the cloud VM
+### Running Unity tests / builds headlessly (Docker + license secrets)
 
-- This is a Unity `6000.5.1f1` game. The **Unity Editor is NOT installed** in the cloud VM and is not part of the update script (it is a multi-GB system dependency that also requires a Unity license). Cloud agents therefore cannot open the project, enter Play mode, build a player, or run the Unity Test Framework tests (EditMode/PlayMode) headlessly.
-- Tests run only in **CI**: `.github/workflows/tests.yml` uses `game-ci/unity-test-runner` inside `unityci/editor:ubuntu-6000.5.1f1-base-3` and needs the `UNITY_LICENSE`, `UNITY_EMAIL`, `UNITY_PASSWORD` repo secrets. Reproducing this locally requires Docker + those same secrets.
-- Do not try to compile the C# assemblies standalone (`dotnet`/`mono`): they depend on `UnityEngine` and are only compiled by the Unity Editor. Verify Unity C# changes by reasoning + CI; the human runs the Editor locally (see the Testing section above).
+Headless EditMode/PlayMode tests and a Linux player build ARE possible in the cloud VM via the GameCI editor image + a Unity license. This is a **heavy one-time setup that is intentionally NOT in the update script** (10.8 GB image + Docker daemon + .NET SDK). If a fresh VM lacks it, reinstall: Docker (dind, `storage-driver: fuse-overlayfs` with `features.containerd-snapshotter: false` on Docker 29+, iptables-legacy), `dotnet-sdk-8.0`, then `docker pull unityci/editor:ubuntu-6000.5.1f1-linux-il2cpp-3` (editor `6000.5.1f1`, includes `LinuxStandaloneSupport`). Start the daemon before use: `sudo dockerd &`.
+
+- **Requires the Unity license secrets** `UNITY_LICENSE` + `UNITY_EMAIL` + `UNITY_PASSWORD` (same as CI). `UNITY_LICENSE` holds the Personal `.ulf` file contents; activation = writing it into the editor's license dir. Without them the editor launches but stops at `No valid Unity Editor license found`.
+- **Run EditMode tests** (swap `EditMode`→`PlayMode` for play tests; CI runs both via `testMode: all`):
+  ```bash
+  sudo docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -e UNITY_LICENSE \
+    -v "$PWD":/project -w /project unityci/editor:ubuntu-6000.5.1f1-linux-il2cpp-3 \
+    bash -lc 'mkdir -p /tmp/.local/share/unity3d/Unity && printf "%s" "$UNITY_LICENSE" > /tmp/.local/share/unity3d/Unity/Unity_lic.ulf && \
+      unity-editor -projectPath /project -runTests -testPlatform EditMode -testResults /project/editmode-results.xml -logFile /dev/stdout'
+  ```
+- **Build a Linux player** (default active scenes; no custom build method exists in-repo):
+  ```bash
+  sudo docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -e UNITY_LICENSE \
+    -v "$PWD":/project -w /project unityci/editor:ubuntu-6000.5.1f1-linux-il2cpp-3 \
+    bash -lc 'mkdir -p /tmp/.local/share/unity3d/Unity && printf "%s" "$UNITY_LICENSE" > /tmp/.local/share/unity3d/Unity/Unity_lic.ulf && \
+      unity-editor -projectPath /project -quit -buildLinux64Player /project/Builds/SpacePixels.x86_64 -logFile /dev/stdout'
+  ```
+- The canonical path is still **CI** (`.github/workflows/tests.yml`, `game-ci/unity-test-runner`, image `...-base-3`). Running tests compiles all game + test assemblies, so it also validates that C# changes compile. The interactive game GUI cannot be meaningfully *played* headlessly (no display) — use batchmode tests/builds instead.
+- Host `.NET SDK` (`dotnet`) is installed but the game's C# is compiled **only by Unity** (assemblies depend on `UnityEngine`); do not expect `dotnet build` on the generated `.csproj`/`.sln` to reflect a real build.
 
 ### What IS runnable in the cloud VM: the Python asset tooling under `python/`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the cloud development environment for this repo and documents it.

This is a Unity `6000.5.1f1` game. The runnable-in-cloud parts are the Python asset tooling under `python/` (installed by the update script) and, for Unity itself, a headless Docker-based test/build toolchain that only needs the Unity license secrets.

### Changes
- Add a `## Cursor Cloud specific instructions` section to `AGENTS.md`:
  - How to run the two Python tools (`sprite_generator`, `icon_downloader`), incl. CWD requirements and the output-path quirk.
  - How to run **headless Unity EditMode/PlayMode tests and a Linux build** via the GameCI editor image + license secrets (exact `docker run` recipes), and that this heavy toolchain is intentionally NOT in the update script.
- Update script (via environment config): installs Python deps `pillow requests types-Pillow` system-wide (idempotent, no system deps).

### Unity / .NET toolchain (set up in the VM, proven ready)
- Docker 29 (dind, `fuse-overlayfs`, containerd-snapshotter disabled), `.NET SDK 8.0.128`.
- Pulled `unityci/editor:ubuntu-6000.5.1f1-linux-il2cpp-3` (Unity `6000.5.1f1`, `LinuxStandaloneSupport`) — matches `ProjectSettings/ProjectVersion.txt`.
- Proven that the editor launches and reaches the license gate; the real `-runTests` command against the project is accepted and only stops at `No valid Unity Editor license found`. So with `UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD` (as in CI), tests + build run.

[unity_toolchain_readiness.log](https://cursor.com/agents/bc-a82d04a0-b15c-4559-b963-8bba0d5a09ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funity_toolchain_readiness.log)

### Python tooling verification
- `sprite_generator` pipeline run end-to-end, producing real pixel-ship PNGs:

[Sprite generator output](https://cursor.com/agents/bc-a82d04a0-b15c-4559-b963-8bba0d5a09ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsprite_generator_output.png)

- `icon_downloader` core verified in isolation (fetched a Material Symbols icon: HTTP 200, sanitized SVG) without modifying tracked assets.

### Note
No source code was changed; only `AGENTS.md` docs were added.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a82d04a0-b15c-4559-b963-8bba0d5a09ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a82d04a0-b15c-4559-b963-8bba0d5a09ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

